### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/src/solver/sudoku_solver.rs
+++ b/src/solver/sudoku_solver.rs
@@ -116,7 +116,7 @@ mod test {
         // otherwise counting doesn't work.
         let mut total_progress = 0;
         for _ in 0..SIZE*SIZE {
-            println!("{:#5.}", &field);
+            println!("{:#5}", &field);
             let progress = solve_step(&field, &mut new_field).unwrap();
             mem::swap(&mut field, &mut new_field);
             total_progress += progress;


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See https://github.com/rust-lang/rust/issues/131159 and https://github.com/rust-lang/rust/pull/136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.